### PR TITLE
[WIP] use nginx for proxying

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,4 @@
+---
+buildpack: staticfile_buildpack
+memory: 64MB
+name: 18f-pages-router

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+# based on https://github.com/18F/cf-redirect/blob/2743de98d1770f293bcb52124146d5f682f0bc6b/nginx.conf
+worker_processes 1;
+daemon off;
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen <%= ENV["PORT"] %>;
+
+    location / {
+      proxy_pass http://federalist.18f.gov.s3-website-us-east-1.amazonaws.com/site/18f/;
+    }
+  }
+}


### PR DESCRIPTION
This is a proof-of-concept, using nginx for proxying requests to 18F pages sites being moved to Federalist, using only the two files you see in this pull request. Demo:

https://18f-pages-router.app.cloud.gov/before-you-ship/

This would just need a pages.18f.gov added as a [custom domain](https://cloud.gov/docs/apps/custom-domains/).

It took some finagling on the Federalist side, but these settings ended up working:

![screen shot 2016-12-03 at 5 31 45 pm](https://cloud.githubusercontent.com/assets/86842/20862637/6527e6c6-b97e-11e6-80b5-f0af6fdb5a9b.png)

Note that the `baseurl` override breaks assets on the preview branch sites. Basically, trying to handle `baseurl`s in some cases but different ones in others is messy 😕  Thoughts?

/cc @ccostino @wslack @NoahKunin @jmhooper @jeremiak 